### PR TITLE
fix: properly handle non-array EntityType.Property

### DIFF
--- a/generators/app/utils.js
+++ b/generators/app/utils.js
@@ -47,12 +47,12 @@ module.exports = {
                         keys: ensureArray(entityType.Key?.PropertyRef)?.map(key => {
                             return key.Name;
                         }),
-                        properties: ensureArray(entityType.Property.map(prop => {
+                        properties: ensureArray(entityType.Property)?.map(prop => {
                             return {
                                 name: prop.Name,
                                 type: prop.Type
                             };
-                        }))
+                        })
                     };
                 });
             });


### PR DESCRIPTION
I believe this was just accidentally wrong braces in the code. Ensuring that the result of `.map()` makes less sense than doing the same for the thing on which it is called, just like two lines above. Especially when the example service shows that `entityType.Property` can be non-arrays.

Fixes https://github.com/ui5-community/generator-ui5-ts-app-fcl/issues/10