### PR TITLE
fix: adjust sync usage of resourceBundle

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -210,6 +210,7 @@ module.exports = class extends Generator {
       this.config.set("gte11150", semver.gte(props.frameworkVersion, "1.115.0"));
       this.config.set("gte11160", semver.gte(props.frameworkVersion, "1.116.0"));
       this.config.set("gte11170", semver.gte(props.frameworkVersion, "1.117.0"));
+      this.config.set("lt11200", semver.lt(props.frameworkVersion, "1.120.0"));
 
       // apply OData settings
       const odataSettings = new URL(props.endpoint);

--- a/generators/app/templates/webapp/Component.ts
+++ b/generators/app/templates/webapp/Component.ts
@@ -119,19 +119,19 @@ export default class Component extends UIComponent {
 	}
 
 	private getFcl(): Promise<FlexibleColumnLayout> {
-		return new Promise((resolve, reject) => {
-			const FCL = ((this.getRootControl() as View).byId('fcl') as FlexibleColumnLayout);
+		return this.rootControlLoaded().then((rootControl) => {
+			const FCL = ((rootControl as View).byId('fcl') as FlexibleColumnLayout);
 			if (!FCL) {<% if (gte11170) { %>
-				(this.getRootControl() as View).attachAfterInit((event: View$AfterInitEvent) => {
-					resolve((event.getSource().byId('fcl') as FlexibleColumnLayout));<% } else if (gte11150) { %>
-				(this.getRootControl() as View).attachAfterInit((event: View$AfterInitEvent) => {
-					resolve(((event.getSource() as View).byId('fcl') as FlexibleColumnLayout)); <% } else { %>
-				(this.getRootControl() as View).attachAfterInit((event: UI5Event) => {
-					resolve(((event.getSource() as View).byId('fcl') as FlexibleColumnLayout)); <% } %>
+				(rootControl as View).attachAfterInit((event: View$AfterInitEvent) => {
+					return (event.getSource().byId('fcl') as FlexibleColumnLayout);<% } else if (gte11150) { %>
+				(rootControl as View).attachAfterInit((event: View$AfterInitEvent) => {
+					return ((event.getSource() as View).byId('fcl') as FlexibleColumnLayout); <% } else { %>
+				(rootControl as View).attachAfterInit((event: UI5Event) => {
+					return ((event.getSource() as View).byId('fcl') as FlexibleColumnLayout); <% } %>
 				});
 				return;
 			}
-			resolve(FCL);
+			return FCL;
 		});
 	}
 }

--- a/generators/app/templates/webapp/controller/BaseController.ts
+++ b/generators/app/templates/webapp/controller/BaseController.ts
@@ -49,11 +49,11 @@ export default class BaseController extends Controller {
 
 	/**
 	 * Convenience method for getting the i18n resource bundle of the component.
-	 * @returns The i18n resource bundle of the component
+	 * @returns {Promise<sap.base.i18n.ResourceModel>} The i18n resource bundle of the component
 	 */
 	public getResourceBundle(): Promise<ResourceBundle> {
 		const oModel = this.getOwnerComponent().getModel("i18n") as ResourceModel;
-		return oModel.getResourceBundle();
+		return oModel.getResourceBundle() as Promise<ResourceBundle>;
 	}
 
 	/**

--- a/generators/app/templates/webapp/i18n/i18n_en.properties
+++ b/generators/app/templates/webapp/i18n/i18n_en.properties
@@ -1,0 +1,59 @@
+# This is the resource bundle for Template app
+
+#XTIT: Application name
+appTitle=<%= application %>
+
+#YDES: Application description
+appDescription=<%= application %>
+
+#~~~ Master View ~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+#XTIT: Master view title with placeholder for the number of items
+masterTitleCount=<%= entity %> ({0})
+
+#XTOL: Tooltip for the search field
+masterSearchTooltip=Enter an <%= entity %> name or a part of it.
+
+#XBLI: text for a list with no data
+masterListNoDataText=No <%= entity %> are currently available
+
+#XBLI: text for a list with no data with filter or search
+masterListNoDataWithFilterOrSearchText=No matching <%= entity %> found
+
+#XSEL: Option to sort the master list by PageTitle
+masterSort1=Sort By <%= title %>
+
+
+#~~~ Detail View ~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+#XTOL: Icon Tab Bar Info
+detailIconTabBarInfo=Info
+
+#XTOL: Icon Tab Bar Attachments
+detailIconTabBarAttachments=Attachments
+
+#XTOL: Tooltip text for close column button
+closeColumn=Close
+
+#~~~ Not Found View ~~~~~~~~~~~~~~~~~~~~~~~
+
+#XTIT: Not found view title
+notFoundTitle=Not Found
+
+detailTitle=<%= entity %>
+
+#YMSG: The PageSet not found text is displayed when there is no PageSet with this id
+noObjectFoundText=This <%= entity %> is not available
+
+#YMSG: The not found text is displayed when there was an error loading the resource (404 error)
+notFoundText=The requested resource was not found
+
+#~~~ Not Available View ~~~~~~~~~~~~~~~~~~~~~~~
+
+#XTIT: Master view title
+notAvailableViewTitle=<%= entity %>
+
+#~~~ Error Handling ~~~~~~~~~~~~~~~~~~~~~~~
+
+#YMSG: Error dialog description
+errorText=Sorry, a technical error occurred! Please try again later.

--- a/generators/app/templates/webapp/index-cdn.html
+++ b/generators/app/templates/webapp/index-cdn.html
@@ -13,7 +13,8 @@
 			src="https://<%= cdnDomain %>/<%= frameworkVersion %>/resources/sap-ui-core.js"
 			data-sap-ui-resourceroots='{
 				"<%= appId %>": "./"
-			}'
+			}'<% if (lt11200) { %>
+			data-sap-ui-theme="<%= defaultTheme %>"<% } %>
 			data-sap-ui-oninit="module:sap/ui/core/ComponentSupport"
 			data-sap-ui-async="true"
 			data-sap-ui-compatVersion="edge"

--- a/generators/app/templates/webapp/index.html
+++ b/generators/app/templates/webapp/index.html
@@ -13,7 +13,8 @@
 			src="resources/sap-ui-core.js"
 			data-sap-ui-resourceroots='{
 				"<%= appId %>": "./"
-			}'
+			}'<% if (lt11200) { %>
+			data-sap-ui-theme="<%= defaultTheme %>"<% } %>
 			data-sap-ui-oninit="module:sap/ui/core/ComponentSupport"
 			data-sap-ui-async="true"
 			data-sap-ui-compatVersion="edge"


### PR DESCRIPTION
I did a proper testing again after my changes from [PR#13](https://github.com/ui5-community/generator-ui5-ts-app-fcl/pull/13) and fund some smaller issues (see list below):
- Adjust usage of resourceBundle which does not work properly anymore after switching the resourceBundle to async
- Make access to rootControl in Component.ts more robust by waiting for the rootControlLoaded promise to resolve
- Add i18n_en.properties to the template
- Add default theme for UI5 versions lt 1.120.0 since it's not available in all patches of LTS versions
- Provide correct ts type and API doc for getResourceBundle method in BaseController.ts