### PR TITLE
fix: re-throw on metadata load failure, fix template literal, normalize URL, simplify boolean parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 test/*/
+test/com.myorg.myapp
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License Status][license-image]][license-url]
 
-Generator which use the official UI5 tooling and support multiple deployment targets such as the SAP Business Technology Platform. This generator was built as a plug-in for the community project [Easy-UI5](https://github.com/SAP/generator-easy-ui5/) by [SAP](https://github.com/SAP/).
+Generator which uses the official UI5 tooling and supports multiple deployment targets such as the SAP Business Technology Platform. This generator was built as a plug-in for the community project [Easy-UI5](https://github.com/SAP/generator-easy-ui5/) by [SAP](https://github.com/SAP/).
 
 ## Usage with easy-ui5
 

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -121,11 +121,11 @@ export default class extends Generator {
     }
 
     if (this.options.newdir !== undefined) { // it's coming as string because it is an argument, not an option, so we can differentiate between "undefined" and "false" value
-      this.options.newdir = this.options.newdir !== "false";
+      this.options.newdir = this.options.newdir !== "false" && this.options.newdir !== false;
     }
 
     if (this.options.initrepo !== undefined) { // same as above
-      this.options.initrepo = this.options.initrepo !== "false";
+      this.options.initrepo = this.options.initrepo !== "false" && this.options.initrepo !== false;
     }
 
     // prepare the needed prompts

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -121,19 +121,11 @@ export default class extends Generator {
     }
 
     if (this.options.newdir !== undefined) { // it's coming as string because it is an argument, not an option, so we can differentiate between "undefined" and "false" value
-      if (this.options.newdir === "false") {
-        this.options.newdir = false;
-      } else if (this.options.newdir === "true") {
-        this.options.newdir = true;
-      }
+      this.options.newdir = this.options.newdir !== "false";
     }
 
     if (this.options.initrepo !== undefined) { // same as above
-      if (this.options.initrepo === "false") {
-        this.options.initrepo = false;
-      } else if (this.options.initrepo === "true") {
-        this.options.initrepo = true;
-      }
+      this.options.initrepo = this.options.initrepo !== "false";
     }
 
     // prepare the needed prompts
@@ -238,7 +230,7 @@ export default class extends Generator {
               })
             ).version;
           } catch (ex) {
-            chalk.red("Failed to lookup latest version for ${npmPackage}! Fallback to min version...");
+            this.log(chalk.red(`Failed to lookup latest version for ${npmPackage}! Fallback to min version...`));
             return minFwkVersion[answers.framework || this.options.framework];
           }
         },

--- a/generators/app/utils.js
+++ b/generators/app/utils.js
@@ -54,34 +54,26 @@ export class ODataMetadata {
   }
 
   static async load(serviceUrl) {
-    try {
-      // load the service metadata
-      const metadataUrl = new URL("$metadata", serviceUrl);
-      const response = await fetch(metadataUrl);
-      if (!response.ok) {
-        const error = new Error(`HTTP error ${response.status}: ${response.statusText}`);
-        error.status = response.status;
-        error.statusText = response.statusText;
-        error.url = response.url;
-        throw error;
-      }
+    // normalize the service URL to always end with a slash
+    const base = serviceUrl.endsWith("/") ? serviceUrl : serviceUrl + "/";
+    const metadataUrl = new URL("$metadata", base);
 
-      const metadataXML = await response.text();
-      const serviceMetadata = new X2JS({
-        attributePrefix: ""
-      }).xml2js(metadataXML);
-
-      // create and return a new ODataMetadata instance
-      return new ODataMetadata(serviceMetadata);
-    } catch (err) {
-      if (err.status) {
-        console.log(`Failed to load the service metadata ${err.url}: ${err.statusText}`);
-      } else if (err instanceof TypeError) {
-        console.log(`Failed to load the service metadata: ${err.cause?.message || err.message}`);
-      } else {
-        console.error(err);
-      }
+    const response = await fetch(metadataUrl);
+    if (!response.ok) {
+      const error = new Error(`HTTP error ${response.status}: ${response.statusText}`);
+      error.status = response.status;
+      error.statusText = response.statusText;
+      error.url = response.url;
+      throw error;
     }
+
+    const metadataXML = await response.text();
+    const serviceMetadata = new X2JS({
+      attributePrefix: ""
+    }).xml2js(metadataXML);
+
+    // create and return a new ODataMetadata instance
+    return new ODataMetadata(serviceMetadata);
   }
 
   getEntitySets() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,14 +12,14 @@
         "chalk": "^5.6.2",
         "glob": "^13.0.6",
         "package-json": "^10.0.1",
-        "semver": "^7.7.4",
+        "semver": "^7.8.5",
         "x2js": "^3.4.4",
-        "yeoman-generator": "^8.0.0",
+        "yeoman-generator": "^8.2.2",
         "yosay": "^3.0.0"
       },
       "devDependencies": {
         "yeoman-assert": "^3.1.1",
-        "yeoman-test": "^11.3.1"
+        "yeoman-test": "^11.6.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -107,10 +107,25 @@
       "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
       "license": "MIT"
     },
+    "node_modules/@simple-git/args-pathspec": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@simple-git/args-pathspec/-/args-pathspec-1.0.3.tgz",
+      "integrity": "sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==",
+      "license": "MIT"
+    },
+    "node_modules/@simple-git/argv-parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@simple-git/argv-parser/-/argv-parser-1.1.1.tgz",
+      "integrity": "sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@simple-git/args-pathspec": "^1.0.3"
+      }
+    },
     "node_modules/@types/debug": {
-      "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
-      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
       "license": "MIT",
       "dependencies": {
         "@types/ms": "*"
@@ -184,17 +199,18 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
-      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       }
     },
     "node_modules/@yeoman/namespace": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@yeoman/namespace/-/namespace-1.0.1.tgz",
-      "integrity": "sha512-XGdYL0HCoPvrzW7T8bxD6RbCY/B8uvR2jpOzJc/yEwTueKHwoVhjSLjVXkokQAO0LNl8nQFLVZ1aKfr2eFWZeA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@yeoman/namespace/-/namespace-2.1.0.tgz",
+      "integrity": "sha512-/BxsZlALPRp34juAzzh9QUr2hR9w9o+dBSw8sF/iv7NfUU/A/QI0xOyVtQJz2uCPuvtY6nkGDxYxZoKI/lnFQg==",
       "license": "MIT",
       "engines": {
         "node": "^16.13.0 || >=18.12.0"
@@ -275,12 +291,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/async": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-      "license": "MIT"
-    },
     "node_modules/b4a": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
@@ -334,9 +344,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -456,13 +466,10 @@
       }
     },
     "node_modules/ejs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-4.0.1.tgz",
-      "integrity": "sha512-krvQtxc0btwSm/nvnt1UpnaFDFVJpJ0fdckmALpCgShsr/iGYHTnJiUliZTgmzq/UxTX33TtOQVKaNigMQp/6Q==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-5.0.2.tgz",
+      "integrity": "sha512-IpbUaI/CAW86l3f+T8zN0iggSc0LmMZLcIW5eRVStLVNCoTXkE0YlncbbH50fp8Cl6zHIky0sW2uUbhBqGw0Jw==",
       "license": "Apache-2.0",
-      "dependencies": {
-        "jake": "^10.9.1"
-      },
       "bin": {
         "ejs": "bin/cli.js"
       },
@@ -542,42 +549,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/filelist": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
-      "integrity": "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "minimatch": "^5.0.1"
-      }
-    },
-    "node_modules/filelist/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
-    },
-    "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/find-up-simple": {
@@ -738,23 +709,6 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
-    "node_modules/jake": {
-      "version": "10.9.4",
-      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
-      "integrity": "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "async": "^3.2.6",
-        "filelist": "^1.0.4",
-        "picocolors": "^1.1.1"
-      },
-      "bin": {
-        "jake": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -789,9 +743,9 @@
       }
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/lru-cache": {
@@ -820,9 +774,9 @@
       }
     },
     "node_modules/mem-fs-editor": {
-      "version": "12.0.2",
-      "resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-12.0.2.tgz",
-      "integrity": "sha512-H31IlLheZAEViQpInX2Wv9YdH98hLMOeqiaSmuENIDoXriQBd7KUmqXOgby0Xgy/9MoZvvDly2k9Zm77EdngAA==",
+      "version": "12.0.4",
+      "resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-12.0.4.tgz",
+      "integrity": "sha512-gc8b4VlisaGp5W+ot2f4Xc8jUgKnMn5UR2mKsdm8UdbESYCdSiQKqioktPu8gJ0Uxd8gV/m/M16Pp5n1Ge8pjA==",
       "license": "MIT",
       "dependencies": {
         "@types/ejs": "^3.1.5",
@@ -831,7 +785,7 @@
         "commondir": "^1.0.1",
         "debug": "^4.4.3",
         "deep-extend": "^0.6.0",
-        "ejs": "^4.0.1",
+        "ejs": "^5.0.1",
         "isbinaryfile": "5.0.7",
         "minimatch": "^10.2.4",
         "multimatch": "^8.0.0",
@@ -1069,6 +1023,18 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
     },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/pretty-ms": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
@@ -1196,9 +1162,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -1241,13 +1207,15 @@
       }
     },
     "node_modules/simple-git": {
-      "version": "3.32.3",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.32.3.tgz",
-      "integrity": "sha512-56a5oxFdWlsGygOXHWrG+xjj5w9ZIt2uQbzqiIGdR/6i5iococ7WQ/bNPzWxCJdEUGUCmyMH0t9zMpRJTaKxmw==",
+      "version": "3.36.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.36.0.tgz",
+      "integrity": "sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==",
       "license": "MIT",
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
+        "@simple-git/args-pathspec": "^1.0.3",
+        "@simple-git/argv-parser": "^1.1.0",
         "debug": "^4.4.0"
       },
       "funding": {
@@ -1483,22 +1451,10 @@
         }
       }
     },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/type-fest": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.4.4.tgz",
-      "integrity": "sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
+      "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
       "license": "(MIT OR CC0-1.0)",
       "dependencies": {
         "tagged-tag": "^1.0.0"
@@ -1661,27 +1617,27 @@
       }
     },
     "node_modules/yeoman-generator": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-8.0.0.tgz",
-      "integrity": "sha512-UB54IKUO5kxaazyYKQ6nq4nJQ9je4hRSvNzlZ1Axwohhau9pkTyBKsizUyIVEZBDli+vqzMlV+0JWwokDbmQDg==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-8.2.2.tgz",
+      "integrity": "sha512-GIvRULf09VrTyJ1nMIxCRFTI8gzW9zsAxVXTHOmsWVKZ7QYPdByRQvFtnp0XOObM6dvDSoAwBhuYR6i5inp/ig==",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@types/debug": "^4.1.12",
+        "@types/debug": "^4.1.13",
         "@types/lodash-es": "^4.17.12",
-        "@yeoman/namespace": "^1.0.1",
+        "@yeoman/namespace": "^2.1.0",
         "chalk": "^5.6.2",
         "debug": "^4.4.3",
         "execa": "^9.6.1",
         "latest-version": "^9.0.0",
-        "lodash-es": "^4.17.23",
-        "mem-fs-editor": "^12.0.2",
+        "lodash-es": "^4.18.1",
+        "mem-fs-editor": "^12.0.4",
         "minimist": "^1.2.8",
         "read-package-up": "^12.0.0",
         "semver": "^7.7.4",
-        "simple-git": "^3.32.3",
+        "simple-git": "^3.36.0",
         "sort-keys": "^6.0.0",
         "text-table": "^0.2.0",
-        "type-fest": "^5.4.4"
+        "type-fest": "^5.6.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -1698,16 +1654,16 @@
       }
     },
     "node_modules/yeoman-test": {
-      "version": "11.3.1",
-      "resolved": "https://registry.npmjs.org/yeoman-test/-/yeoman-test-11.3.1.tgz",
-      "integrity": "sha512-bEaKyfTliYtHpu/cukkdkfB1w5r8LfntRj83/DQTIt0hbXQnYwsada3D+VoTAaOpvLeqJ8NGscyu5G3V7Xb7NA==",
+      "version": "11.6.0",
+      "resolved": "https://registry.npmjs.org/yeoman-test/-/yeoman-test-11.6.0.tgz",
+      "integrity": "sha512-sT3p4qXwTtOobZsLjrzJs3CFs1Rl5vSOByMdkpJ1s/qu63fcYYd7LPr0qkgacRxSTqy+zap3BhblhVSJyylV6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "lodash-es": "^4.17.23",
-        "mem-fs-editor": "^12.0.2",
+        "lodash-es": "^4.18.1",
+        "mem-fs-editor": "^12.0.3",
         "signal-exit": "^4.1.0",
-        "type-fest": "^5.4.4"
+        "type-fest": "^5.6.0"
       },
       "engines": {
         "node": "^20.6.1 || >=22"

--- a/package.json
+++ b/package.json
@@ -23,13 +23,13 @@
     "chalk": "^5.6.2",
     "glob": "^13.0.6",
     "package-json": "^10.0.1",
-    "semver": "^7.7.4",
+    "semver": "^7.8.5",
     "x2js": "^3.4.4",
-    "yeoman-generator": "^8.0.0",
+    "yeoman-generator": "^8.2.2",
     "yosay": "^3.0.0"
   },
   "devDependencies": {
     "yeoman-assert": "^3.1.1",
-    "yeoman-test": "^11.3.1"
+    "yeoman-test": "^11.6.0"
   }
 }


### PR DESCRIPTION
Follow-up fixes from reviewing PR #16:

- **ODataMetadata.load():** remove try/catch so errors propagate to callers (prevents silent undefined metadata causing downstream TypeError)
- **Normalize serviceUrl:** always end with `/` before constructing `$metadata` URL (fixes incorrect URL resolution per URL spec)
- **Fix string template:** use backticks and `this.log()` for `npmPackage` interpolation (was rendering literal `${npmPackage}` and discarding the result)
- **Boolean argument parsing:** only parse `"false"` as `false`, default to `true` (simplifies logic, avoids unhandled string values passing through unconverted)